### PR TITLE
Scan for and burn any forced subtitles

### DIFF
--- a/transcode.sh
+++ b/transcode.sh
@@ -223,6 +223,8 @@ function transcode() {
 
     if [ -e "$srt_file" ]; then
       subtitle_options="--add-srt $work_dir/$srt_file"
+    else
+      subtitle_options="--burn-subtitle scan"
     fi
   }
 


### PR DESCRIPTION
This resolves #12 by scanning for forced subtitles if no .srt file is found.